### PR TITLE
fix：睡眠定时器在切歌前暂停，避免循环与自动播放导致失效

### DIFF
--- a/lib/src/providers/audio_provider.dart
+++ b/lib/src/providers/audio_provider.dart
@@ -459,16 +459,24 @@ final miniPlayerVisibilityProvider =
 
 // Sleep Timer Controller
 class SleepTimerController extends StateNotifier<SleepTimerState> {
-  final Ref _ref;
+  final AudioPlayerService _service;
+  final Future<void> Function() pause;
+  final DateTime Function() _now;
   Timer? _timer;
   Timer? _countdownTimer;
   StreamSubscription? _trackSubscription;
+  StreamSubscription<void>? _trackEndSubscription;
 
-  SleepTimerController(this._ref) : super(const SleepTimerState());
+  SleepTimerController(
+    this._service, {
+    required this.pause,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now,
+       super(const SleepTimerState());
 
   /// 设置定时器（按时长）
   void setTimer(Duration duration, {bool finishCurrentTrack = false}) {
-    final endTime = DateTime.now().add(duration);
+    final endTime = _now().add(duration);
     _setTimerInternal(endTime, finishCurrentTrack: finishCurrentTrack);
   }
 
@@ -482,7 +490,7 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
     // 取消现有定时器
     cancelTimer();
 
-    final duration = endTime.difference(DateTime.now());
+    final duration = endTime.difference(_now());
 
     // 如果时间已经过了，则不设置
     if (duration.isNegative || duration.inSeconds < 1) {
@@ -494,17 +502,13 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
       if (state.finishCurrentTrack) {
         _waitForTrackEndAndPause();
       } else {
-        final audioController =
-            _ref.read(audioPlayerControllerProvider.notifier);
-        audioController.pause();
-        // 定时器结束后重置状态
-        cancelTimer();
+        unawaited(_pauseAndCancel());
       }
     });
 
     // 设置倒计时更新定时器 - 每秒更新一次剩余时间
     _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      final remaining = endTime.difference(DateTime.now());
+      final remaining = endTime.difference(_now());
       if (remaining.isNegative) {
         timer.cancel();
         return;
@@ -523,6 +527,15 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
       remainingTime: duration,
       finishCurrentTrack: finishCurrentTrack,
     );
+
+    if (finishCurrentTrack) {
+      // Check the wall-clock deadline even if a background Timer callback is late.
+      _trackEndSubscription = _service.trackEndStream.listen((_) {
+        if (!_now().isBefore(endTime)) {
+          unawaited(_pauseAndCancel());
+        }
+      });
+    }
   }
 
   /// 等待当前音轨播放结束并暂停
@@ -532,11 +545,12 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
     _countdownTimer?.cancel();
     _countdownTimer = null;
 
-    final audioController = _ref.read(audioPlayerControllerProvider.notifier);
-    final initialTrack = audioController.currentTrack;
+    final initialTrack = _service.currentTrack;
 
-    if (initialTrack == null) {
-      cancelTimer();
+    if (initialTrack == null ||
+        !_service.playing ||
+        _service.playerState.processingState == ProcessingState.completed) {
+      unawaited(_pauseAndCancel());
       return;
     }
 
@@ -546,15 +560,23 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
     );
 
     _trackSubscription?.cancel();
-    _trackSubscription = audioController.currentTrackStream.listen(
-      (track) {
-        // 当音轨发生变化（切换到下一首或停止）时暂停
-        if (track?.id != initialTrack.id) {
-          audioController.pause();
-          cancelTimer();
-        }
-      },
-    );
+    _trackSubscription = _service.currentTrackStream.listen((track) {
+      // 当音轨发生变化（切换到下一首或停止）时暂停
+      if (track?.id != initialTrack.id) {
+        unawaited(_pauseAndCancel());
+      }
+    });
+  }
+
+  Future<void> _pauseAndCancel() async {
+    // Start pausing synchronously so completion cannot advance the queue.
+    final pausing = Future<void>.sync(pause);
+    cancelTimer();
+    try {
+      await pausing;
+    } catch (error) {
+      _log.captureOutput('[SleepTimer] Failed to pause playback: $error');
+    }
   }
 
   /// 取消定时器
@@ -565,20 +587,20 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
     _countdownTimer = null;
     _trackSubscription?.cancel();
     _trackSubscription = null;
+    _trackEndSubscription?.cancel();
+    _trackEndSubscription = null;
     state = const SleepTimerState();
   }
 
   /// 添加时间（延长定时器）
   void addTime(Duration duration) {
     if (state.isActive && state.endTime != null) {
-      final newEndTime = state.endTime!.add(duration);
-      final newRemaining = newEndTime.difference(DateTime.now());
+      final now = _now();
+      final baseTime = state.endTime!.isAfter(now) ? state.endTime! : now;
+      final newEndTime = baseTime.add(duration);
 
       // 重新设置定时器，并保持当前的"播完暂停"状态
-      setTimer(
-        newRemaining,
-        finishCurrentTrack: state.finishCurrentTrack,
-      );
+      setTimerUntil(newEndTime, finishCurrentTrack: state.finishCurrentTrack);
     }
   }
 
@@ -587,6 +609,7 @@ class SleepTimerController extends StateNotifier<SleepTimerState> {
     _timer?.cancel();
     _countdownTimer?.cancel();
     _trackSubscription?.cancel();
+    _trackEndSubscription?.cancel();
     super.dispose();
   }
 }
@@ -641,5 +664,8 @@ class SleepTimerState {
 // Sleep Timer Provider
 final sleepTimerProvider =
     StateNotifierProvider<SleepTimerController, SleepTimerState>((ref) {
-  return SleepTimerController(ref);
-});
+      return SleepTimerController(
+        ref.read(audioPlayerServiceProvider),
+        pause: () => ref.read(audioPlayerControllerProvider.notifier).pause(),
+      );
+    });

--- a/lib/src/services/audio_player_service.dart
+++ b/lib/src/services/audio_player_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;
+import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
@@ -41,6 +42,16 @@ class AudioPlayerService {
     }
   }
 
+  @visibleForTesting
+  AudioPlayerService.forTesting(
+    AudioPlayer player, {
+    List<AudioTrack> queue = const [],
+  }) {
+    _player = player;
+    _queue.addAll(queue);
+    _setupPlayerListeners();
+  }
+
   late final AudioPlayer _player;
   AndroidLoudnessEnhancer? _androidLoudnessEnhancer;
   final AudioHapticsService _hapticsService = AudioHapticsService.instance;
@@ -60,6 +71,7 @@ class AudioPlayerService {
   bool _isRestoringSession = false;
   bool _sessionCompleted = false;
   bool _handlingTrackCompletion = false;
+  int _pauseGeneration = 0;
   String? _sessionOwnerKey;
 
   // 下一首预加载：剩余时长低于此阈值时提前缓存下一首，避免切歌空档
@@ -117,6 +129,11 @@ class AudioPlayerService {
       StreamController.broadcast();
   final StreamController<bool> _trackLoadingController =
       StreamController<bool>.broadcast();
+  // Synchronous delivery lets a sleep timer veto repeat/advance before it starts.
+  final StreamController<void> _trackEndController =
+      StreamController<void>.broadcast(sync: true);
+
+  Stream<void> get trackEndStream => _trackEndController.stream;
 
   // Initialize the service
   Future<void> initialize() async {
@@ -251,7 +268,7 @@ class AudioPlayerService {
 
     // Listen to player state changes
     _player.playerStateStream.listen((state) {
-      if (state.processingState == ProcessingState.completed) {
+      if (state.playing && state.processingState == ProcessingState.completed) {
         if (Platform.isMacOS) {
           // macOS: Use dedicated handler to prevent duplicate triggers
           if (!_completionHandled) {
@@ -610,9 +627,14 @@ class AudioPlayerService {
 
   // Handle track completion logic
   Future<void> _handleTrackCompletion() async {
-    if (_sessionCompleted || _handlingTrackCompletion) return;
+    if (!_player.playing || _sessionCompleted || _handlingTrackCompletion) {
+      return;
+    }
     _handlingTrackCompletion = true;
     try {
+      final pauseGeneration = _pauseGeneration;
+      _trackEndController.add(null);
+      if (pauseGeneration != _pauseGeneration) return;
       if (_appLoopMode == LoopMode.one) {
         // Single track repeat - replay current track
         // macOS: Reset completion flag before replaying to allow next completion detection
@@ -620,6 +642,7 @@ class AudioPlayerService {
           _completionHandled = false;
         }
         await seek(Duration.zero);
+        if (pauseGeneration != _pauseGeneration) return;
         unawaited(play());
       } else if (_currentIndex < _queue.length - 1) {
         // Has next track - play it
@@ -778,6 +801,7 @@ class AudioPlayerService {
   }
 
   Future<void> pause() async {
+    _pauseGeneration++;
     await _player.pause();
     _updatePlaybackState();
     await _hapticsService.pause();
@@ -785,6 +809,7 @@ class AudioPlayerService {
   }
 
   Future<void> stop() async {
+    _pauseGeneration++;
     await _player.stop();
     _updatePlaybackState();
     await _hapticsService.stop();
@@ -850,10 +875,12 @@ class AudioPlayerService {
   }
 
   Future<void> _switchToIndexAndPlay(int index) async {
+    final pauseGeneration = _pauseGeneration;
     final previousIndex = _currentIndex;
     _currentIndex = index;
     try {
       await _loadTrack(_queue[_currentIndex]);
+      if (pauseGeneration != _pauseGeneration) return;
       await play();
     } catch (_) {
       _currentIndex = previousIndex;
@@ -1265,6 +1292,7 @@ class AudioPlayerService {
     await _cleanupTempPlaybackFile();
     await _queueController.close();
     await _currentTrackController.close();
+    await _trackEndController.close();
     await _player.dispose();
   }
 

--- a/test/sleep_timer_playback_test.dart
+++ b/test/sleep_timer_playback_test.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:kikoeru_flutter/src/models/audio_track.dart';
+import 'package:kikoeru_flutter/src/providers/audio_provider.dart';
+import 'package:kikoeru_flutter/src/services/audio_player_service.dart';
+
+const _first = AudioTrack(
+  id: '1',
+  title: 'First',
+  url: 'https://example.test/1',
+);
+const _second = AudioTrack(
+  id: '2',
+  title: 'Second',
+  url: 'https://example.test/2',
+);
+
+class _Player extends Fake implements AudioPlayer {
+  final states = StreamController<PlayerState>.broadcast();
+  int plays = 0;
+  int seeks = 0;
+  int loads = 0;
+  Completer<Duration?>? loading;
+  Completer<void>? seeking;
+
+  @override
+  bool playing = true;
+  @override
+  ProcessingState processingState = ProcessingState.ready;
+  @override
+  PlayerState get playerState => PlayerState(playing, processingState);
+  @override
+  Stream<PlayerState> get playerStateStream => states.stream;
+  @override
+  Stream<Duration> get positionStream => const Stream.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream.empty();
+
+  void complete() {
+    processingState = ProcessingState.completed;
+    states.add(playerState);
+  }
+
+  @override
+  Future<void> play() async {
+    plays++;
+    playing = true;
+  }
+
+  @override
+  Future<void> pause() async {
+    playing = false;
+    states.add(playerState); // Pausing at EOF emits another completed state.
+  }
+
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {
+    seeks++;
+    await seeking?.future;
+    processingState = ProcessingState.ready;
+  }
+
+  @override
+  Future<Duration?> setUrl(
+    String url, {
+    Map<String, String>? headers,
+    Duration? initialPosition,
+    bool preload = true,
+    dynamic tag,
+  }) async {
+    loads++;
+    await loading?.future;
+    processingState = ProcessingState.ready;
+    return const Duration(minutes: 10);
+  }
+
+  @override
+  Future<void> setLoopMode(LoopMode mode) async {}
+
+  @override
+  Future<void> dispose() => states.close();
+}
+
+// Keep persistence out of these tests while exercising the real playback logic.
+class _Service extends AudioPlayerService {
+  _Service(super.player, {required super.queue}) : super.forTesting();
+
+  @override
+  Future<void> persistPlaybackPosition() async {}
+  @override
+  Future<void> persistPlaybackSession() async {}
+}
+
+void main() {
+  for (final mode in LoopMode.values) {
+    testWidgets('normal playback still advances or repeats in $mode', (
+      tester,
+    ) async {
+      final player = _Player();
+      final service = _Service(player, queue: [_first, _second]);
+      await service.setRepeatMode(mode);
+      player.complete();
+      await tester.pump();
+      expect(player.plays, 1);
+      expect(player.seeks, mode == LoopMode.one ? 1 : 0);
+      expect(player.loads, mode == LoopMode.one ? 0 : 1);
+      await service.dispose();
+    });
+
+    testWidgets('sleep completion prevents advance/repeat in $mode', (
+      tester,
+    ) async {
+      final player = _Player();
+      final service = _Service(player, queue: [_first, _second]);
+      final timer = SleepTimerController(
+        service,
+        pause: service.pause,
+        now: tester.binding.clock.now,
+      );
+      await service.setRepeatMode(mode);
+      timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+      await tester.pump(const Duration(seconds: 5));
+      player.complete();
+      await tester.pump();
+      // Flush the second completed notification caused by pause as well.
+      await tester.pump();
+      expect(player.playing, isFalse);
+      expect(player.plays, 0);
+      expect(player.loads, 0);
+      expect(player.seeks, 0);
+      expect(timer.state.isActive, isFalse);
+      timer.dispose();
+      await service.dispose();
+    });
+  }
+
+  testWidgets(
+    'timer pause during next-track loading is not undone by autoplay',
+    (tester) async {
+      final player = _Player()..loading = Completer<Duration?>();
+      final service = _Service(player, queue: [_first, _second]);
+      final timer = SleepTimerController(
+        service,
+        pause: service.pause,
+        now: tester.binding.clock.now,
+      );
+      timer.setTimer(const Duration(seconds: 5));
+      final switching = service.skipToNext();
+      await tester.pump();
+      expect(player.loads, 1);
+      await tester.pump(const Duration(seconds: 5));
+      expect(player.playing, isFalse);
+      player.loading!.complete(const Duration(minutes: 10));
+      await switching;
+      expect(player.plays, 0);
+      timer.dispose();
+      await service.dispose();
+    },
+  );
+
+  testWidgets('timer pause during repeat seek is not undone by autoplay', (
+    tester,
+  ) async {
+    final player = _Player()..seeking = Completer<void>();
+    final service = _Service(player, queue: [_first]);
+    final timer = SleepTimerController(
+      service,
+      pause: service.pause,
+      now: tester.binding.clock.now,
+    );
+    await service.setRepeatMode(LoopMode.one);
+    timer.setTimer(const Duration(seconds: 5));
+    player.complete();
+    await tester.pump();
+    expect(player.seeks, 1);
+    await tester.pump(const Duration(seconds: 5));
+    player.seeking!.complete();
+    await tester.pump();
+    expect(player.playing, isFalse);
+    expect(player.plays, 0);
+    timer.dispose();
+    await service.dispose();
+  });
+}

--- a/test/sleep_timer_test.dart
+++ b/test/sleep_timer_test.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:kikoeru_flutter/src/models/audio_track.dart';
+import 'package:kikoeru_flutter/src/providers/audio_provider.dart';
+import 'package:kikoeru_flutter/src/services/audio_player_service.dart';
+
+const _track = AudioTrack(id: 'one', title: 'One', url: 'file:///one.mp3');
+
+class _FakeAudioService implements AudioPlayerService {
+  final tracks = StreamController<AudioTrack?>.broadcast(sync: true);
+  final ends = StreamController<void>.broadcast(sync: true);
+  int pauseCount = 0;
+
+  @override
+  AudioTrack? currentTrack = _track;
+
+  @override
+  bool playing = true;
+
+  @override
+  PlayerState get playerState => PlayerState(playing, processingState);
+  ProcessingState processingState = ProcessingState.ready;
+
+  @override
+  Stream<AudioTrack?> get currentTrackStream => tracks.stream;
+
+  @override
+  Stream<void> get trackEndStream => ends.stream;
+
+  @override
+  Future<void> pause() async {
+    pauseCount++;
+    playing = false;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _FakeAudioService audio;
+  late SleepTimerController timer;
+
+  void initialize(WidgetTester tester, {DateTime Function()? now}) {
+    audio = _FakeAudioService();
+    timer = SleepTimerController(
+      audio,
+      pause: audio.pause,
+      now: now ?? tester.binding.clock.now,
+    );
+    addTearDown(() async {
+      timer.dispose();
+      await audio.tracks.close();
+      await audio.ends.close();
+    });
+  }
+
+  testWidgets('deadline pauses once without finishing the track', (
+    tester,
+  ) async {
+    initialize(tester);
+    timer.setTimer(const Duration(seconds: 5));
+    await tester.pump(const Duration(seconds: 4));
+    expect(audio.pauseCount, 0);
+    await tester.pump(const Duration(seconds: 1));
+    expect(audio.pauseCount, 1);
+    expect(timer.state.isActive, isFalse);
+    await tester.pump(const Duration(seconds: 10));
+    expect(audio.pauseCount, 1);
+  });
+
+  testWidgets(
+    'completion pauses synchronously even when track ID stays the same',
+    (tester) async {
+      initialize(tester);
+      timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+      audio.ends.add(
+        null,
+      ); // Completion before the deadline must not stop playback.
+      expect(audio.pauseCount, 0);
+      await tester.pump(const Duration(seconds: 5));
+      expect(timer.state.waitingForTrackEnd, isTrue);
+      expect(audio.pauseCount, 0);
+      audio.ends.add(null); // Single-track repeat / one-item looping queue.
+      expect(audio.playing, isFalse);
+      expect(audio.pauseCount, 1);
+      expect(timer.state.isActive, isFalse);
+      audio.ends.add(null);
+      expect(audio.pauseCount, 1);
+    },
+  );
+
+  testWidgets('last-track completion clears the waiting state', (tester) async {
+    initialize(tester);
+    timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+    await tester.pump(const Duration(seconds: 5));
+    audio.processingState = ProcessingState.completed;
+    audio.ends.add(null);
+    expect(timer.state.isActive, isFalse);
+    expect(audio.pauseCount, 1);
+  });
+
+  testWidgets('manual track change or queue clearing also stops waiting', (
+    tester,
+  ) async {
+    initialize(tester);
+    timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+    await tester.pump(const Duration(seconds: 5));
+    audio.tracks.add(_track); // Metadata updates are not a track boundary.
+    expect(audio.pauseCount, 0);
+    audio.tracks.add(null);
+    expect(audio.pauseCount, 1);
+    expect(timer.state.isActive, isFalse);
+  });
+
+  for (final status in ['paused', 'completed', 'empty']) {
+    testWidgets('deadline does not wait forever when player is $status', (
+      tester,
+    ) async {
+      initialize(tester);
+      if (status == 'paused') audio.playing = false;
+      if (status == 'completed') {
+        audio.processingState = ProcessingState.completed;
+      }
+      if (status == 'empty') audio.currentTrack = null;
+      timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+      await tester.pump(const Duration(seconds: 5));
+      expect(timer.state.isActive, isFalse);
+      expect(audio.pauseCount, 1);
+    });
+  }
+
+  testWidgets(
+    'extension while waiting starts from now and removes old listeners',
+    (tester) async {
+      initialize(tester);
+      timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+      await tester.pump(const Duration(minutes: 10));
+      expect(timer.state.waitingForTrackEnd, isTrue);
+      timer.addTime(const Duration(minutes: 5));
+      expect(timer.state.remainingTime, const Duration(minutes: 5));
+      expect(timer.state.waitingForTrackEnd, isFalse);
+      expect(timer.state.finishCurrentTrack, isTrue);
+      audio.ends.add(null);
+      expect(audio.pauseCount, 0);
+      await tester.pump(const Duration(minutes: 5));
+      audio.ends.add(null);
+      expect(audio.pauseCount, 1);
+    },
+  );
+
+  testWidgets('cancel and replacement prevent stale timer callbacks', (
+    tester,
+  ) async {
+    initialize(tester);
+    timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+    await tester.pump(const Duration(seconds: 5));
+    timer.cancelTimer();
+    audio.ends.add(null);
+    audio.tracks.add(null);
+    expect(audio.pauseCount, 0);
+    timer.setTimer(const Duration(seconds: 5));
+    timer.setTimer(const Duration(seconds: 10));
+    await tester.pump(const Duration(seconds: 5));
+    expect(audio.pauseCount, 0);
+    await tester.pump(const Duration(seconds: 5));
+    expect(audio.pauseCount, 1);
+  });
+
+  testWidgets(
+    'track completion checks deadline before a delayed timer callback',
+    (tester) async {
+      var now = DateTime(2026, 9, 5);
+      initialize(tester, now: () => now);
+      timer.setTimer(const Duration(seconds: 5), finishCurrentTrack: true);
+      // Simulate wall time advancing while background timer dispatch is delayed.
+      now = now.add(const Duration(seconds: 10));
+      audio.ends.add(null);
+      expect(audio.pauseCount, 1);
+      expect(timer.state.isActive, isFalse);
+      await tester.pump(const Duration(seconds: 10));
+      expect(audio.pauseCount, 1);
+    },
+  );
+}


### PR DESCRIPTION
勾选「播完当前音轨」后，睡眠定时器可能无法停止播放：单曲循环不会改变曲目 ID，而切歌后发出的暂停又可能被尚未完成的自动播放流程覆盖。此次问题反馈来自 Android，开启了该选项，可能处于锁屏状态。

本次修改在循环或切换下一首之前通知睡眠定时器，并在音轨结束时核对截止时间，补防后台定时回调延迟。暂停或停止请求会使尚未完成的切歌加载、单曲循环定位操作取消后续自动播放；暂停时产生的重复「播放结束」通知也不会再推进队列。

同时修复等待播完期间延长时间的问题：截止时间已过时，从当前时间开始延长；到期时若已暂停、播放结束或队列为空，则清理定时器，不再无限等待。

验证情况：
- 新增 18 项回归测试，覆盖到期处理、曲目 ID 不变、取消与重新设置、延长时间、回调延迟、全部循环模式，以及暂停与自动播放的竞争。播放时序测试使用真实播放服务搭配模拟播放器。
- 使用 Flutter 3.44.7 运行相关测试，共 28 项通过：sleep_timer_test、sleep_timer_playback_test、audio_playback_plan_builder_test、playback_session_store_test、android_audio_backend_guard_test。
- 两个修改的源码文件及两个新增测试文件均通过静态分析，无问题；git diff --check 通过。
- 尚未在 Android 真机上验证锁屏场景。